### PR TITLE
Manhattanplot option to annotate highlighted SNVs

### DIFF
--- a/qmplot/modules/_manhattan.py
+++ b/qmplot/modules/_manhattan.py
@@ -26,6 +26,7 @@ def manhattanplot(data, chrom="#CHROM", pos="POS", pv="P", snp="ID", logp=True, 
                   sign_marker_p=None, sign_marker_color="r",
                   is_annotate_topsnp=False, highlight_other_SNPs_indcs=None,
                   highlight_other_SNPs_color="r", highlight_other_SNPs_kwargs=None,
+                  annotate_highlighted_SNPs=False,
                   text_kws=None, ld_block_size=50000, **kwargs):
     """Creates a manhattan plot from PLINK assoc output (or any data frame with chromosome, position, and p-value).
 
@@ -122,6 +123,9 @@ def manhattanplot(data, chrom="#CHROM", pos="POS", pv="P", snp="ID", logp=True, 
 
     highlight_other_SNPs_kwargs=None : Dict, or None, optional
         Dict of keyword arguments passed to the command highlighting the other SNPs.
+
+    annotate_highlighted_SNPs=False : bool, optional
+        Set to True to annotated SNVs highlted with "highlight_other_SNPs_indcs".
 
     text_kws: key, value pairings, or None, optional
         keyword arguments for plotting in`` matplotlib.axes.Axes.text(x, y, s, fontdict=None, **kwargs)``
@@ -312,6 +316,12 @@ def manhattanplot(data, chrom="#CHROM", pos="POS", pv="P", snp="ID", logp=True, 
         for i in highlight_other_SNPs_indcs:
             ax.scatter(x[i], y[i], c=highlight_other_SNPs_color,
                        alpha=alpha, edgecolors="none", **highlight_other_SNPs_kwargs)
+        if annotate_highlighted_SNPs and (snp is not None): # to annotate highlighted SNVs
+            texts = [] 
+            for i in highlight_other_SNPs_indcs:
+                snp_id = data[snp].iloc[i]
+                texts.append(ax.text(x[i], y[i], snp_id)) # x_pos, y_value, text (snp ID)
+            adjust_text(texts, ax=ax, **text_kws)
 
     # Add GWAS significant lines
     if "color" in hline_kws:


### PR DESCRIPTION
Hi!
Here I've added an option to also annotate SNVs provided with "highlight_other_SNPs_indcs" argument.

So if one wants to compare to GWAS results via Manhattanplot or just they just have genes of interest they want to highlight then there is an example below:

```
# let's consider that processing and creation of a list with SNVs indices is above
# so we have 2 different GWAS experiments and a set of target SNVs

fig, axs = plt.subplots(2, 1, figsize=(10, 8))

manhattanplot(
    data = GWAS_1,
    chrom = 'CHROM',
    pos = 'GENPOS',
    pv = 'pval',
    snp = 'Gene',
    suggestiveline=1e-6,
    genomewideline=1e-8,
    highlight_other_SNPs_indcs=SNVs_to_annotate,
    highlight_other_SNPs_color='magenta',
    ax=axs[0],
    annotate_highlighted_SNPs=True # NEW ARGUMENT
)

manhattanplot(
    data = GWAS_2,
    chrom = 'CHROM',
    pos = 'GENPOS',
    pv = 'pval',
    snp = 'Gene',
    suggestiveline=1e-6,
    genomewideline=1e-8,
    highlight_other_SNPs_indcs=SNVs_to_annotate,
    highlight_other_SNPs_color='magenta',
    annotate_highlighted_SNPs=True, # NEW ARGUMENT
    ax=axs[1]
)

plt.show()
```
Resultant picture:

![изображение](https://github.com/ShujiaHuang/qmplot/assets/47666260/2a5b1699-9ebe-4333-974f-8def8d01d59b)
